### PR TITLE
インストールパッケージを複数行に書き直してソートした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@ FROM ocaml/opam2:ubuntu-18.04-ocaml-4.07 as builder
 USER root
 RUN apt update && \
     apt install -y --no-install-recommends \
-        build-essential \
         autoconf \
-        git \
-        m4 \
-        unzip \
-        wget \
+        build-essential \
         ca-cacert \
         ca-certificates \
-        ruby
+        git \
+        m4 \
+        ruby \
+        unzip \
+        wget
 
 USER opam
 WORKDIR /home/opam

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 FROM ocaml/opam2:ubuntu-18.04-ocaml-4.07 as builder
 
 USER root
-RUN apt update &&\
-    apt -y --no-install-recommends install build-essential autoconf git m4 unzip wget ca-cacert ca-certificates ruby
+RUN apt update && \
+    apt install -y --no-install-recommends \
+        build-essential \
+        autoconf \
+        git \
+        m4 \
+        unzip \
+        wget \
+        ca-cacert \
+        ca-certificates \
+        ruby
 
 USER opam
 WORKDIR /home/opam


### PR DESCRIPTION
[Dockerfileのベストプラクティス](http://docs.docker.jp/engine/articles/dockerfile_best-practice.html#id6)にある「引数のソート」をしたほうが良いのでは、と思った次第です。

生成されるDockerイメージは変わらないと思います。